### PR TITLE
Add gzip handling to file-mover

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: file-mover
 description: A Helm chart energinet-singularity/file-mover
 
-version: 0.2.0
+version: 0.2.1
 
-appVersion: "1.16.0"
+appVersion: "0.2.1"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: file-mover
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.0"
+  tag: "0.2.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/filemover.py
+++ b/filemover.py
@@ -102,7 +102,8 @@ def move_files(input_path, output_path, dryrun=False):
         if verbose or dryrun: print(f"Read file '{input_file}' from input folder.")
 
     #Unpack gzip'd files
-    for output_file in filedict:
+    keylist = list(filedict.keys())
+    for output_file in keylist:
         if output_file[-3:] == '.gz':
             filedict[output_file[:-3]] = gzip.decompress(filedict.pop(output_file))
 

--- a/filemover.py
+++ b/filemover.py
@@ -1,5 +1,5 @@
 #Import dependencies
-import os, sys, smbclient, sched, time, smbclient.path as smb_path #Not sure why .path is not directly accessible
+import os, sys, gzip, smbclient, sched, time, smbclient.path as smb_path #Not sure why .path is not directly accessible
 
 #Load/set variables
 smb_username = os.environ.get('SMB_USERNAME')                                       #No default value
@@ -100,6 +100,11 @@ def move_files(input_path, output_path, dryrun=False):
         else:
             if remove_input and not dryrun: remove_in(input_path + input_file)
         if verbose or dryrun: print(f"Read file '{input_file}' from input folder.")
+
+    #Unpack gzip'd files
+    for output_file in filedict:
+        if output_file[-3:] == '.gz':
+            filedict[output_file[:-3]] = gzip.decompress(filedict.pop(output_file))
 
     #Write files from directory
     for output_file in filedict:


### PR DESCRIPTION
included gzip lib - when all files read, check for extension and decompress in case .gz.

Resolves #4 