### PR TITLE
Fix incorrect path variable

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: file-mover
 description: A Helm chart energinet-singularity/file-mover
-version: 1.1.0
+version: 1.1.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/energinet-singularity/file-mover/energinet-singularity/file-mover
   pullPolicy: IfNotPresent
-  tag: "1.1.0"
+  tag: "1.1.1"
 
 #Following settings (credentials) must be commented out if using samba
 #smbUserName: "user"


### PR DESCRIPTION
Fix of bug where incorrect variable name broke the clean-up function and crashed the entire code each iteration.

Furthermore, logging now only changed to 'INFO' level for __main__ module (rest at default-levels) and the archive-dir can be created if not found. Yeah yeah - atomic changes. I know.